### PR TITLE
Changed notify icon to address not show up during quiet start

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -18,20 +18,47 @@ namespace Handheld_Hardware_Tools
     {
 
         public SplashScreenStartUp splashWindow;
-
+        public static System.Windows.Forms.NotifyIcon icon;
         public App()
         {
-
+ 
             //run this so that everything shuts down when the main window closes
             Application.Current.ShutdownMode = ShutdownMode.OnMainWindowClose;
 
-
+            SetUpNotifyIcon();
             //string dir = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
             //string stringsFile = Path.Combine(dir, "Styles", "DefaultTheme.xaml");
             //LoadStyleDictionaryFromFile(stringsFile);
 
 
         }
+
+        private void SetUpNotifyIcon()
+        {
+            App.icon = new System.Windows.Forms.NotifyIcon();
+            icon.Icon = System.Drawing.Icon.ExtractAssociatedIcon(AppDomain.CurrentDomain.BaseDirectory + "Handheld Hardware Tools.exe");
+            icon.Visible = true;
+            icon.Click += Icon_Click;
+        
+        }
+             
+
+        private void Icon_Click(object? sender, EventArgs e)
+        {
+            System.Windows.Forms.MouseEventArgs mouseEventArgs = (System.Windows.Forms.MouseEventArgs)e;
+
+            if (mouseEventArgs.Button == System.Windows.Forms.MouseButtons.Left)
+            {
+                QuickAccessMenu qam = Local_Object.Instance.GetQAMWindow();
+
+                if (qam != null)
+                {
+                    qam.ToggleWindow();
+                }
+            }
+
+        }
+
         private void Application_DispatcherUnhandledException(object sender, System.Windows.Threading.DispatcherUnhandledExceptionEventArgs e)
         {
             string message = "An unhandled exception just occurred: " + e.Exception.Message + ". Stack Trace: " + e.Exception.StackTrace + ". Source: " + e.Exception.Source + ". Inner Exception: " + e.Exception.InnerException;

--- a/Handheld Hardware Tools.csproj
+++ b/Handheld Hardware Tools.csproj
@@ -210,6 +210,7 @@
     <PackageReference Include="PowerManagerAPI" Version="0.2.0-CI-20200413-015121" />
     <PackageReference Include="RadialMenu.WPF" Version="1.3.0" />
     <PackageReference Include="SharpDX.XInput" Version="4.2.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
     <PackageReference Include="System.Management" Version="7.0.2" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.0" />
     <PackageReference Include="TaskScheduler" Version="2.10.1" />

--- a/QuickAccessMenu.xaml
+++ b/QuickAccessMenu.xaml
@@ -66,20 +66,7 @@
         </Grid.RowDefinitions>
     
        
-        <ui:NotifyIcon
-                Grid.Row="0"
-                x:Name="notifyIcon"
-                FocusOnLeftClick="True"
-                Visibility="Visible"
-                MenuOnRightClick="True"
-                TooltipText="HandheldHardware Tools" LeftClick="notifyIcon_LeftClick">
-            <ui:NotifyIcon.Menu>
-                <ContextMenu >
-                    <MenuItem Header="{DynamicResource ContextMenu_Show}"  Click="ContextMenu_Show"/>
-                    <MenuItem Header="{DynamicResource ContextMenu_Close}" Click="ContextMenu_Close"/>
-                </ContextMenu>
-            </ui:NotifyIcon.Menu>
-        </ui:NotifyIcon>
+     
         <DockPanel  Grid.Column="0" Grid.ColumnSpan="2">
             <Image  Name="MainWindowLogo" Margin="10,4,0,4" />
 

--- a/QuickAccessMenu.xaml.cs
+++ b/QuickAccessMenu.xaml.cs
@@ -420,16 +420,10 @@ namespace Handheld_Hardware_Tools
             //Write log to tell app is closing
             Log_Writer.Instance.writeLog("App closing");
 
-            //unload notify icon
-            UnloadNotifyIcon();
+          
         }
 
-        private void UnloadNotifyIcon()
-        {
-            notifyIcon.Dispose();
-            notifyIcon = null;
-        }
-
+     
         private void UnsubscribeEvents()
         {
             //unsubscribe to controller input


### PR DESCRIPTION
Removed ui notify icon from mainwindow and added notifyicon to app.xaml.cs to address bug where notifyicon wouldn't show up until the mainwindow was shown